### PR TITLE
feat: support start hash parameter [NS]

### DIFF
--- a/lib/fastlane/plugin/semantic_release2/actions/conventional_changelog.rb
+++ b/lib/fastlane/plugin/semantic_release2/actions/conventional_changelog.rb
@@ -33,7 +33,7 @@ module Fastlane
 
         # Get commits log between last version and head
         commits = get_commits_from_hash(
-          hash: last_tag_hash,
+          hash: params[:start] || last_tag_hash,
           end: params[:end],
           debug: params[:debug]
         )
@@ -234,6 +234,12 @@ module Fastlane
             description: "You can change the order of groups in release notes",
             default_value: ["feat", "fix", "refactor", "perf", "chore", "test", "docs", "no_type"],
             type: Array,
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :start,
+            description: "Use a commit hash instead of HEAD",
+            type: String,
             optional: true
           ),
           FastlaneCore::ConfigItem.new(

--- a/lib/fastlane/plugin/semantic_release2/helper/semantic_release_helper.rb
+++ b/lib/fastlane/plugin/semantic_release2/helper/semantic_release_helper.rb
@@ -13,7 +13,7 @@ module Fastlane
         if params[:end] and !params[:end].empty?
           end_hash = params[:end]
         end
-        command = "git log --pretty='#{params[:pretty]}' --reverse #{params[:start]}.."
+        command = "git log --pretty='#{params[:pretty]}' --reverse #{params[:start]}..#{end_hash}"
         Actions.sh(command, log: params[:debug]).chomp
       end
 


### PR DESCRIPTION
This new parameter makes it possible to get commits between a range, not just between HEAD and a specific hash.